### PR TITLE
修正panel方向切换时有right-stick属性的插件位移的问题

### DIFF
--- a/ukui-panel/panel-profile.c
+++ b/ukui-panel/panel-profile.c
@@ -331,7 +331,7 @@ panel_profile_set_toplevel_orientation (PanelToplevel    *toplevel,
 					PanelOrientation  orientation)
 {
 	if(orientation == PANEL_ORIENTATION_LEFT || orientation == PANEL_ORIENTATION_RIGHT) {
-		GSettings * narea =  g_settings_new_with_path("org.mate.panel.object", "/org/mate/panel/objects/indicators/");
+		GSettings * narea =  g_settings_new_with_path("org.ukui.panel.object", "/org/ukui/panel/objects/indicators/");
 		g_settings_set_boolean(narea,PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, False);
 	}
 	g_settings_set_enum (toplevel->settings, "orientation", orientation);

--- a/ukui-panel/panel-profile.c
+++ b/ukui-panel/panel-profile.c
@@ -333,6 +333,8 @@ panel_profile_set_toplevel_orientation (PanelToplevel    *toplevel,
 	if(orientation == PANEL_ORIENTATION_LEFT || orientation == PANEL_ORIENTATION_RIGHT) {
 		GSettings * narea =  g_settings_new_with_path("org.ukui.panel.object", "/org/ukui/panel/objects/indicators/");
 		g_settings_set_boolean(narea,PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, False);
+		GSettings * workspace_area =  g_settings_new_with_path("org.ukui.panel.object", "/org/ukui/panel/objects/workspace-switcher/");
+		g_settings_set_boolean(workspace_area,PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, False);
 	}
 	g_settings_set_enum (toplevel->settings, "orientation", orientation);
 }

--- a/ukui-panel/panel-profile.c
+++ b/ukui-panel/panel-profile.c
@@ -330,6 +330,9 @@ void
 panel_profile_set_toplevel_orientation (PanelToplevel    *toplevel,
 					PanelOrientation  orientation)
 {
+	if(orientation == PANEL_ORIENTATION_LEFT || orientation == PANEL_ORIENTATION_RIGHT) {
+		GSettings * narea =  g_settings_new_with_path("org.mate.panel.object", "/org/mate/panel/objects/indicators/");
+		g_settings_set_boolean(narea,PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, False);
 	g_settings_set_enum (toplevel->settings, "orientation", orientation);
 }
 

--- a/ukui-panel/panel-profile.c
+++ b/ukui-panel/panel-profile.c
@@ -333,6 +333,7 @@ panel_profile_set_toplevel_orientation (PanelToplevel    *toplevel,
 	if(orientation == PANEL_ORIENTATION_LEFT || orientation == PANEL_ORIENTATION_RIGHT) {
 		GSettings * narea =  g_settings_new_with_path("org.mate.panel.object", "/org/mate/panel/objects/indicators/");
 		g_settings_set_boolean(narea,PANEL_OBJECT_PANEL_RIGHT_STICK_KEY, False);
+	}
 	g_settings_set_enum (toplevel->settings, "orientation", orientation);
 }
 


### PR DESCRIPTION
目前发现的位移会产生的问题
1.indicator显示不在底部
2.workspace-switch占据了window-list的位置导致window-list显示成一条直线