### PR TITLE
Fix build under Arch

### DIFF
--- a/cmake/ukui-build-tools/modules/UKUiAppTranslationLoader.cpp.in
+++ b/cmake/ukui-build-tools/modules/UKUiAppTranslationLoader.cpp.in
@@ -5,7 +5,7 @@
  */
 
 #include <QCoreApplication>
-#include "../../panel/common/ukuitranslator.h"
+#include "../panel/common/ukuitranslator.h"
 
 static void loadAppTranslation()
 {

--- a/cmake/ukui-build-tools/modules/UKUiPluginTranslationLoader.cpp.in
+++ b/cmake/ukui-build-tools/modules/UKUiPluginTranslationLoader.cpp.in
@@ -7,7 +7,7 @@
 #include <QCoreApplication>
 #include <QLatin1String>
 
-#include "../../panel/common/ukuitranslator.h"
+#include "../panel/common/ukuitranslator.h"
 
 /* Dummy helper symbol for referencing.
  * In case plugin is linked as static (lib*.a) unreferenced objects are stripped in linking time


### PR DESCRIPTION
Currently the header file is not found when building in a separate
"build" directory.