### PR TITLE
UKUITaskGroup::showPreview(): when XGetImage return a nullptr, return directly.

### DIFF
--- a/plugin-taskbar/ukuitaskgroup.cpp
+++ b/plugin-taskbar/ukuitaskgroup.cpp
@@ -740,6 +740,8 @@ void UKUITaskGroup::showPreview()
         XGetWindowAttributes(display, it.key(), &attr);
         img = XGetImage(display, it.key(), 0, 0, attr.width, attr.height, 0xffffffff,ZPixmap);
 
+        if (!img)
+            return;
         QPixmap thumbnail = qimageFromXImage(img).scaled(THUMBNAIL_WIDTH,THUMBNAIL_HEIGHT,Qt::KeepAspectRatio,Qt::FastTransformation);
         thumbnail.save(QString("/tmp/picture/%1.png").arg(it.key()));
         //QLabel * label = new QLabel; // 创建堆对象


### PR DESCRIPTION
Sometimes we could not get a correct data from display in KWin. That will lead panel crash.

I just avoid the crash problem here, so that there no be a serious bug caused, but the problem why sometimes we can not get the resouces in KWin has not been resolved.