### PR TITLE
Fix full-width space in #define

### DIFF
--- a/plugin-nightmode/nightmode.cpp
+++ b/plugin-nightmode/nightmode.cpp
@@ -26,7 +26,7 @@
 #include "../panel/customstyle.h"
 
 #define NIGHT_MODE_KEY        "nightmodestatus"
-#define NIGHT_MODE_LIGHT 　　　"light"
+#define NIGHT_MODE_LIGHT      "light"
 #define NIGHE_MODE_NIGHT      "night"
 #define NIGHT_MODE_CONTROL    "org.ukui.control-center.panel.plugins"
 


### PR DESCRIPTION
Fixes build error:

```
ukui-panel/plugin-nightmode/nightmode.cpp:29:26: error: extended
character 　 is not valid in an identifier
   29 | #define NIGHT_MODE_LIGHT 　　　"light"
         |                          ^
```