### PR TITLE
About the font which showed in date of panel

### DIFF
--- a/plugin-calendar/ukuicalendar.cpp
+++ b/plugin-calendar/ukuicalendar.cpp
@@ -47,7 +47,7 @@
 #include <QSize>
 #include <QScreen>
 
-#define CALENDAR_HEIGHT (40)
+#define CALENDAR_HEIGHT(a) (a-5)
 #define CALENDAR_WIDTH (104)
 
 #define WEBVIEW_WIDTH (454)
@@ -829,13 +829,14 @@ void IndicatorCalendar::realign()
 
 void IndicatorCalendar::setTimeShowStyle()
 {
+    int size = panel()->panelSize();
     if(panel()->isHorizontal())
     {
-        mContent->setFixedSize(CALENDAR_WIDTH,panel()->panelSize() - 5); //CALENDAR_HEIGHT);//panel()->panelSize() - 5);
+        mContent->setFixedSize(CALENDAR_WIDTH, CALENDAR_HEIGHT(size));
     }
     else
     {
-        mContent->setFixedSize(panel()->panelSize() - 5,CALENDAR_WIDTH);
+        mContent->setFixedSize(CALENDAR_HEIGHT(size), CALENDAR_WIDTH);
     }
     mbIsNeedUpdate = true;
     timeout();

--- a/plugin-calendar/ukuicalendar.cpp
+++ b/plugin-calendar/ukuicalendar.cpp
@@ -169,27 +169,6 @@ IndicatorCalendar::IndicatorCalendar(const IUKUIPanelPluginStartupInfo &startupI
     }
 
     setTimeShowStyle();
-    mContent->setStyleSheet(
-                //正常状态样式
-                "QLabel{"
-                /*"background-color:rgba(100,225,100,80%);"//背景色（也可以设置图片）*/
-                "border-width:0px;"                        //边框宽度像素
-                "border-radius:6px;"                       //边框圆角半径像素
-                "font: SourceHanSansCN-Medium  12px;"      //字体，字体大小
-                "color:rgba(255,255,255,100%);"            //字体颜色
-                "padding:0px;"                             //填衬
-                "textalignment:aligncenter"                //文本居中
-                "}"
-                //鼠标悬停样式
-                "QLabel:hover{"
-                "background-color:rgba(190,216,239,20%);"
-                "}"
-                //鼠标按下样式
-                "QLabel:pressed{"
-                "background-color:rgba(190,216,239,12%);"
-                "}"
-
-                );
     mContent->setWordWrap(true);
     setToolTip();
 }
@@ -328,6 +307,26 @@ void IndicatorCalendar::updateTimeText()
     mContent->setText(str);
     if (old_size != mContent->sizeHint())
         mRotatedWidget->adjustContentSize();
+    mContent->setStyleSheet(
+                //正常状态样式
+                "QLabel{"
+                "border-width:  0px;"                     //边框宽度像素
+                "border-radius: 6px;"                       //边框圆角半径像素
+                "font-size:     14px;"                      //字体，字体大小
+                "color:         rgba(255,255,255,100%);"    //字体颜色
+                "padding:       0px;"                       //填衬
+                "text-align:center;"                        //文本居中
+                "}"
+                //鼠标悬停样式
+                "QLabel:hover{"
+                "background-color:rgba(190,216,239,20%);"
+                "border-radius:6px;"                       //边框圆角半径像素
+                "}"
+                //鼠标按下样式
+                "QLabel:pressed{"
+                "background-color:rgba(190,216,239,12%);"
+                "}"
+                );
     mRotatedWidget->update();
     updatePopupContent();
     mbIsNeedUpdate = false;
@@ -832,11 +831,11 @@ void IndicatorCalendar::setTimeShowStyle()
 {
     if(panel()->isHorizontal())
     {
-        mContent->setFixedSize(CALENDAR_WIDTH,CALENDAR_HEIGHT);
+        mContent->setFixedSize(CALENDAR_WIDTH,panel()->panelSize() - 5); //CALENDAR_HEIGHT);//panel()->panelSize() - 5);
     }
     else
     {
-        mContent->setFixedSize(CALENDAR_HEIGHT,CALENDAR_WIDTH);
+        mContent->setFixedSize(panel()->panelSize() - 5,CALENDAR_WIDTH);
     }
     mbIsNeedUpdate = true;
     timeout();

--- a/plugin-calendar/ukuiwebviewdialog.cpp
+++ b/plugin-calendar/ukuiwebviewdialog.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2019 Tianjin KYLIN Information Technology Co., Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -27,6 +27,8 @@
 #include <QApplication>
 #include <QSize>
 #include <QScreen>
+#include <QBitmap>
+#include <QPainter>
 
 #define CALENDAR_MAX_HEIGHT 704
 #define CALENDAR_MIN_HEIGHT 600
@@ -121,7 +123,15 @@ void UkuiWebviewDialog::creatwebview(int _mode, int _panelSize)
             iViewHeight = 600;
         }
         /*set window no margins*/
-        mWebView->setWindowFlags(Qt::FramelessWindowHint);
+        mWebView->setWindowFlags(Qt::FramelessWindowHint);setWindowFlags(Qt::FramelessWindowHint);
+        /*set rounded corner ,including radius*/
+        QBitmap bmp(iViewWidth,iViewHeight);
+        bmp.fill();
+        QPainter p(&bmp);
+        p.setPen(Qt::NoPen);
+        p.setBrush(Qt::black);
+        p.drawRoundedRect(bmp.rect(),6,6);
+        setMask(bmp);
         /*set window size*/
         mWebView->resize(iViewWidth,iViewHeight);
         mWebView->settings()->setAttribute(QWebSettings::JavascriptEnabled,true);


### PR DESCRIPTION
1. Fixed the bug in Issues #338 
2. Fixed the bug in the time and date of the task bar, when changing the font style globally, it don't change.
3. Fixed the bug in the time and date of the task bar, when changing the size of the panel, the size of the date button don't change.