### PR TITLE
2020/07/31- ?

### DIFF
--- a/plugin-taskbar/ukuitaskgroup.cpp
+++ b/plugin-taskbar/ukuitaskgroup.cpp
@@ -1191,6 +1191,20 @@ void UKUITaskGroup::showAllWindowByThumbnail()
     mpWidget->setAttribute(Qt::WA_TranslucentBackground);
     setLayOutForPostion();
     /*begin catch preview picture*/
+
+    int pop_sum = mButtonHash.size();
+    int max_Height = 0;
+    int imgWidth_sum = 0;
+    float minimum = THUMBNAIL_WIDTH;
+    for (UKUITaskButtonHash::const_iterator it = mButtonHash.begin();it != mButtonHash.end();it++)
+    {
+        display = XOpenDisplay(nullptr);
+        XGetWindowAttributes(display, it.key(), &attr);
+        imgWidth_sum += attr.width;
+        max_Height = attr.height > max_Height ? attr.height : max_Height;
+        if(display)
+            XCloseDisplay(display);
+    }
     for (UKUITaskButtonHash::const_iterator it = mButtonHash.begin();it != mButtonHash.end();it++)
     {
         UKUITaskWidget *btn = it.value();
@@ -1200,7 +1214,18 @@ void UKUITaskGroup::showAllWindowByThumbnail()
         img = XGetImage(display, it.key(), 0, 0, attr.width, attr.height, 0xffffffff,ZPixmap);
         if(img)
         {
-            thumbnail = qimageFromXImage(img).scaled(THUMBNAIL_WIDTH,THUMBNAIL_HEIGHT,Qt::KeepAspectRatio,Qt::SmoothTransformation);
+            float imgWidth = (float)attr.width / (float)imgWidth_sum * pop_sum * THUMBNAIL_WIDTH;
+            float imgHeight = THUMBNAIL_HEIGHT;
+            if (attr.height != max_Height)
+            {
+                float tmp = (float)attr.height / (float)max_Height;
+                imgHeight =  imgHeight * tmp;
+            }
+            if ((int)imgWidth > (int)minimum)
+            {
+                imgWidth = minimum;
+            }
+            thumbnail = qimageFromXImage(img).scaled((int)imgWidth, (int)imgHeight, Qt::KeepAspectRatio,Qt::SmoothTransformation);
             //thumbnail.save(QString("/tmp/picture/%1.png").arg(it.key()));  test picture if correct
         }
         else

--- a/plugin-taskbar/ukuitaskgroup.h
+++ b/plugin-taskbar/ukuitaskgroup.h
@@ -57,6 +57,7 @@ public:
 
     int buttonsCount() const;
     int visibleButtonsCount() const;
+    void initVisibleHash();
 
     QWidget * addWindow(WId id);
     QWidget * checkedButton() const;
@@ -81,6 +82,7 @@ public:
     void showAllWindowByList();//when number of window is more than 30,need show all window of app by a list
     void showAllWindowByThumbnail();//when number of window is no more than 30,need show all window of app by a thumbnail
     void singleWindowClick();
+    void VisibleWndRemoved(WId window);
 public slots:
     void onWindowRemoved(WId window);
     void timeout();
@@ -124,6 +126,7 @@ private:
     UKUIGroupPopup * mPopup;
     QVBoxLayout *VLayout;
     UKUITaskButtonHash mButtonHash;
+    UKUITaskButtonHash mVisibleHash;
     bool mPreventPopup;
     bool mSingleButton; //!< flag if this group should act as a "standard" button (no groupping or only one "shown" window in group)
     enum TaskGroupStatus{NORMAL, HOVER, PRESS};

--- a/plugin-taskbar/ukuitaskgroup.h
+++ b/plugin-taskbar/ukuitaskgroup.h
@@ -141,6 +141,7 @@ private:
     QPoint recalculateFramePosition();
     void recalculateFrameIfVisible();
     void adjustPopWindowSize(int width, int height);
+    void v_adjustPopWindowSize(int width, int height, int * v_width);
     void regroup();
 
 };

--- a/plugin-taskbar/ukuitaskwidget.cpp
+++ b/plugin-taskbar/ukuitaskwidget.cpp
@@ -141,7 +141,8 @@ UKUITaskWidget::UKUITaskWidget(const WId window, UKUITaskBar * taskbar, QWidget 
 //    mTopBarLayout->addWidget(mCloseBtn, 0, Qt::AlignRight | Qt::AlignVCenter);
     //    mVWindowsLayout->setAlignment(Qt::AlignCenter);
     mVWindowsLayout->addLayout(mTopBarLayout);
-    mVWindowsLayout->addWidget(mThumbnailLabel/*, 0, Qt::AlignBottom*/);
+    mVWindowsLayout->addWidget(mThumbnailLabel, Qt::AlignVCenter, Qt::AlignVCenter);
+    mVWindowsLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
     this->setLayout(mVWindowsLayout);
     updateText();
     updateIcon();

--- a/plugin-taskbar/ukuitaskwidget.cpp
+++ b/plugin-taskbar/ukuitaskwidget.cpp
@@ -39,6 +39,7 @@
 #include <QStylePainter>
 #include <QStyleOptionToolButton>
 #include <QDesktopWidget>
+#include <QScreen>
 
 #include "ukuitaskgroup.h"
 #include "ukuitaskbar.h"
@@ -99,7 +100,7 @@ UKUITaskWidget::UKUITaskWidget(const WId window, UKUITaskBar * taskbar, QWidget 
     //    mTitleLabel->setContentsMargins(0,0,0,10);
     //    mTitleLabel->adjustSize();
     //    mTitleLabel->setStyleSheet("QLabel{background-color: red;}");
-    //    mTitleLabel->setFixedWidth(120);
+
     mThumbnailLabel = new QLabel;
     mAppIcon = new QLabel;
     mVWindowsLayout = new QVBoxLayout;
@@ -136,11 +137,11 @@ UKUITaskWidget::UKUITaskWidget(const WId window, UKUITaskBar * taskbar, QWidget 
     mTitleLabel->setContentsMargins(0, 0, 5, 0);
     //    mTopBarLayout->setSpacing(5);
     mTopBarLayout->addWidget(mAppIcon, 0, Qt::AlignLeft | Qt::AlignVCenter);
-    mTopBarLayout->addWidget(mTitleLabel, 1, Qt::AlignVCenter);
+    mTopBarLayout->addWidget(mTitleLabel, 10, Qt::AlignLeft);
     //    mTopBarLayout->addStretch();
 //    mTopBarLayout->addWidget(mCloseBtn, 0, Qt::AlignRight | Qt::AlignVCenter);
     //    mVWindowsLayout->setAlignment(Qt::AlignCenter);
-    mVWindowsLayout->addLayout(mTopBarLayout);
+    mVWindowsLayout->addLayout(mTopBarLayout, 5);
     mVWindowsLayout->addWidget(mThumbnailLabel, Qt::AlignVCenter, Qt::AlignVCenter);
     mVWindowsLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
     this->setLayout(mVWindowsLayout);
@@ -791,4 +792,16 @@ void UKUITaskWidget::addThumbNail()
     {
         return;
     }
+}
+
+
+void UKUITaskWidget::setTitleFixedWidth(int size)
+{
+    mTitleLabel->setFixedWidth(size);
+    mTitleLabel->adjustSize();
+}
+
+int UKUITaskWidget::getWidth()
+{
+    return mTitleLabel->width();
 }

--- a/plugin-taskbar/ukuitaskwidget.h
+++ b/plugin-taskbar/ukuitaskwidget.h
@@ -69,10 +69,12 @@ public:
      * */
     bool hasDragAndDropHover() const;
     void setThumbNail(QPixmap _pixmap);
+    void setTitleFixedWidth(int size);
     void updateTitle();
     void removeThumbNail();
     void addThumbNail();
     void setPixmap(QPixmap mPixmap);
+    int getWidth();
     QPixmap getPixmap();
 
 public slots:


### PR DESCRIPTION
6c26c6f    预览窗口的显示比例设置
5d429ee  不同工作区间的预览窗口显隐问题
dbaeb65  优化预览窗口缩放机制和显示机制，为美观和显示比例考虑，减少最大窗口数从13减少为10个，解决单个小窗口缩放不 
协调的问题，解决窗口数过多时的图片缩放比例显示问题