### PR TITLE
resovle taskbar layout crash fixed #445

### DIFF
--- a/panel/ukuipanel.cpp
+++ b/panel/ukuipanel.cpp
@@ -627,6 +627,7 @@ void UKUIPanel::setMargins()
 */
 void UKUIPanel::realign()
 {
+    updateStyleSheet();
     if (!isVisible())
         return;
 #if 0


### PR DESCRIPTION
Adjust the position of the taskbar to ‘left’ or 'left', the taskbar icon is abnormal, I solved this problem.