### PR TITLE
夜间模式插件更新

### DIFF
--- a/plugin-nightmode/nightmode.cpp
+++ b/plugin-nightmode/nightmode.cpp
@@ -130,27 +130,20 @@ NightModeButton::~NightModeButton(){
 /*NOTE:目前夜间模式的点击按钮实现的是　设置夜间模式＋切换主题*/
 void NightModeButton::mousePressEvent(QMouseEvent *event)
 {
+    if(!QGSettings::isSchemaInstalled(NIGHT_MODE_CONTROL) || !gsettings->keys().contains(NIGHT_MODE_KEY))
+        return;
     if(event->button()==Qt::LeftButton){
-        if(QGSettings::isSchemaInstalled(NIGHT_MODE_CONTROL)){
-            if(mode){
-                if(gsettings->keys().contains(NIGHT_MODE_KEY)){
-                    gsettings->set(NIGHT_MODE_KEY, true);
-                    setNightMode(true);
-                    setUkuiStyle("ukui-black");
-                    mode=false;
-                }
-            }
-            else{
-                if(gsettings->keys().contains(NIGHT_MODE_KEY)){
-                    gsettings->set(NIGHT_MODE_KEY, false);
-                    setNightMode(false);
-                    setUkuiStyle("ukui-white");
-                    mode=true;
-                }
-            }
+        if(gsettings->get(NIGHT_MODE_KEY).toBool()){
+            gsettings->set(NIGHT_MODE_KEY, false);
+            setNightMode(false);
+            setUkuiStyle("ukui-white");
+            qDebug()<<"gsettings->get(NIGHT_MODE_KEY).toBool():"<<gsettings->get(NIGHT_MODE_KEY).toBool();
+        }else{
+            gsettings->set(NIGHT_MODE_KEY, true);
+            setNightMode(true);
+            setUkuiStyle("ukui-black");
+            qDebug()<<"gsettings->get(NIGHT_MODE_KEY).toBool()2:"<<gsettings->get(NIGHT_MODE_KEY).toBool();
         }
-        else
-            QMessageBox::information(this,"Error",tr("please install new ukui-control-center first"));
     }
 }
 
@@ -223,7 +216,7 @@ void NightModeButton::setNightMode(const bool nightMode){
          * /.config/redshift.conf　未设置
          * 需要任务栏设置初始化夜间模式的时间及色温
          * 其他情况下任务栏应读取控制面板设置的参数
-　　　　　*/
+         */
         mqsettings->beginGroup("redshift");
         if(mqsettings->value("temp-day", "").toString().isEmpty()){
             mqsettings->setValue("dawn-time", "17:54");

--- a/plugin-nightmode/nightmode.cpp
+++ b/plugin-nightmode/nightmode.cpp
@@ -120,9 +120,6 @@ NightModeButton::NightModeButton( IUKUIPanelPlugin *plugin, QWidget* parent):
         QIcon icon=QIcon("/usr/share/ukui-panel/panel/img/nightmode-night.svg");
         this->setIcon(icon);
     }
-
-    // init kwin settings
-    setupSettings();
 }
 NightModeButton::~NightModeButton(){
     delete gsettings;
@@ -140,7 +137,6 @@ void NightModeButton::mousePressEvent(QMouseEvent *event)
                     gsettings->set(NIGHT_MODE_KEY, true);
                     setNightMode(true);
                     setUkuiStyle("ukui-black");
-                    writeKwinSettings(true,"ukui-black");
                     mode=false;
                 }
             }
@@ -149,7 +145,6 @@ void NightModeButton::mousePressEvent(QMouseEvent *event)
                     gsettings->set(NIGHT_MODE_KEY, false);
                     setNightMode(false);
                     setUkuiStyle("ukui-white");
-                    writeKwinSettings(true,"ukui-white");
                     mode=true;
                 }
             }
@@ -189,7 +184,6 @@ void NightModeButton::turnNightMode()
                 gsettings->set(NIGHT_MODE_KEY, true);
                 setNightMode(true);
                 setUkuiStyle("ukui-black");
-                writeKwinSettings(true,"ukui-black");
                 mode=false;
             }
         }
@@ -198,7 +192,6 @@ void NightModeButton::turnNightMode()
                 gsettings->set(NIGHT_MODE_KEY, false);
                 setNightMode(false);
                 setUkuiStyle("ukui-white");
-                writeKwinSettings(true,"ukui-white");
                 mode=true;
             }
         }
@@ -291,28 +284,6 @@ void NightModeButton::setUkuiStyle(QString style)
             qWarning()<<tr("don't contains the keys style-name");
 
     }
-}
-
-/*Kwin初始化　*/
-void NightModeButton::setupSettings()
-{
-    QString filename = QDir::homePath() + "/.config/kdeglobals";
-    kwinSettings = new QSettings(filename, QSettings::IniFormat);
-}
-
-/*设置与Kwin　窗口管理器　标题栏颜色*/
-void NightModeButton::writeKwinSettings(bool change, QString theme)
-{
-    QString th;
-    if ("ukui-white" == theme) {
-        th = "0";
-    } else {
-        th = "1";
-    }
-    kwinSettings->beginGroup("Theme");
-    kwinSettings->setValue("Style", th);
-    kwinSettings->endGroup();
-    kwinSettings->sync();
 }
 
 void NightModeButton::enterEvent(QEvent *) {

--- a/plugin-nightmode/nightmode.h
+++ b/plugin-nightmode/nightmode.h
@@ -47,7 +47,6 @@ protected:
 private:
     void setNightMode(const bool nightMode);
     void setUkuiStyle(QString );
-    void writeKwinSettings(bool change, QString theme);
 
     IUKUIPanelPlugin * mPlugin;
     QMenu *nightModeMenu;

--- a/plugin-quicklaunch/quicklaunchaction.cpp
+++ b/plugin-quicklaunch/quicklaunchaction.cpp
@@ -69,7 +69,7 @@ QuickLaunchAction::QuickLaunchAction(const XdgDesktopFile * xdg,
 
     m_settingsMap["desktop"] = xdg->fileName();
 
-    QString title(xdg->localizedValue("GenericName").toString());
+    QString title(xdg->localizedValue("Name").toString());
     QString icon(xdg->localizedValue("Icon").toString());
     setText(title);
 

--- a/plugin-quicklaunch/ukuiquicklaunch.cpp
+++ b/plugin-quicklaunch/ukuiquicklaunch.cpp
@@ -639,7 +639,7 @@ bool UKUIQuickLaunch::RemoveFromTaskbar(QString arg)
 }
 
 /*从任务栏上移除文件的接口*/
-bool UKUIQuickLaunch::FileDeleteFromTaskbar(QString file)
+void UKUIQuickLaunch::FileDeleteFromTaskbar(QString file)
 {
     int i=0;
     bool flag = true;

--- a/plugin-quicklaunch/ukuiquicklaunch.h
+++ b/plugin-quicklaunch/ukuiquicklaunch.h
@@ -133,7 +133,7 @@ private slots:
 public slots:
     bool AddToTaskbar(QString arg);
     bool RemoveFromTaskbar(QString arg);
-    bool FileDeleteFromTaskbar(QString arg);
+    void FileDeleteFromTaskbar(QString arg);
     bool CheckIfExist(QString arg);
     int GetPanelPosition(QString arg);
     int GetPanelSize(QString arg);


### PR DESCRIPTION
1.删除与对Kwin进行的特殊处理（Kwin的特殊处理交给setting-daemo）
2.解决夜间模式按钮与控制面板交互的问题
3.quicklaunch插件引发的任务栏cpu高占用的问题