### PR TITLE
Fix the error order of the quick launch button when save it.

### DIFF
--- a/panel/highlight-effect.cpp
+++ b/panel/highlight-effect.cpp
@@ -376,7 +376,6 @@ QPixmap HighLightEffect::drawSymbolicColoredPixmap(const QPixmap &source)
                 {
                     img.setPixelColor(x, y, color);
                 }
-//                qDebug()<<"color   *&***** :"<<color.red();
             }
         }
     }
@@ -409,7 +408,6 @@ QIcon HighLightEffect::drawSymbolicColoredIcon(const QIcon &source)
                     color=QColor(COLOR_BLACK);
                     img.setPixelColor(x, y, color);
                 }
-                qDebug()<<"color   *&***** :"<<color.red();
             }
         }
     }

--- a/plugin-taskbar/ukuitaskbutton.cpp
+++ b/plugin-taskbar/ukuitaskbutton.cpp
@@ -244,9 +244,7 @@ void UKUITaskButton::dropEvent(QDropEvent *event)
     if (event->mimeData()->hasFormat(mimeDataFormat()))
     {
         //emit dropped(event->source(), event->pos());
-        qDebug() << "in button dropped";
         setAttribute(Qt::WA_UnderMouse, false);
-        emit t_saveSettings();
     }
     QToolButton::dropEvent(event);
 }


### PR DESCRIPTION
* The error order of the quick launch button when save it.
- 解决保存快速启动按钮时发生的顺序错误的问题