### PR TITLE
满足安卓兼容窗口图标变化后任务栏图标实时更新的需求

### DIFF
--- a/plugin-calendar/ukuicalendar.cpp
+++ b/plugin-calendar/ukuicalendar.cpp
@@ -527,7 +527,7 @@ void IndicatorCalendar::settingsChanged()
         realign();
     }
 
-//    setTimeText();
+    setTimeText();
 }
 
 

--- a/plugin-nightmode/nightmode.cpp
+++ b/plugin-nightmode/nightmode.cpp
@@ -156,7 +156,7 @@ void NightModeButton::setNightMode(const bool nightMode){
                              QDBusConnection::sessionBus());
 
     if (!iproperty.isValid()) {
-        qDebug() << "this is invalid";
+        this->setVisible(false);
         return;
     }
     QHash<QString, QVariant> data;

--- a/plugin-quicklaunch/quicklaunchaction.cpp
+++ b/plugin-quicklaunch/quicklaunchaction.cpp
@@ -74,10 +74,23 @@ QuickLaunchAction::QuickLaunchAction(const XdgDesktopFile * xdg,
     m_settingsMap["desktop"] = xdg->fileName();
 
     QString title(xdg->localizedValue("Name").toString());
-    QString icon(xdg->localizedValue("Icon").toString());
+    QIcon icon=QIcon::fromTheme(xdg->localizedValue("Icon").toString());
+    //add special path search /use/share/pixmaps
+    if (icon.isNull())
+    {
+        QString path = QString("/usr/share/pixmaps/%1.%2").arg(xdg->localizedValue("Icon").toString()).arg("png");
+        QString path_svg = QString("/usr/share/pixmaps/%1.%2").arg(xdg->localizedValue("Icon").toString()).arg("svg");
+        //qDebug() << "createDesktopFileThumbnail path:" <<path;
+        if(QFile::exists(path)){
+            icon=QIcon(path);
+        }
+        else if(QFile::exists(path_svg)){
+            icon=QIcon(path_svg);
+        }
+    }
     setText(title);
 
-    setIcon(QIcon::fromTheme(icon));
+    setIcon(icon);
 
     setData(xdg->fileName());
     connect(this, &QAction::triggered, this, [this] { execAction(); });

--- a/plugin-taskbar/ukuitaskbutton.cpp
+++ b/plugin-taskbar/ukuitaskbutton.cpp
@@ -118,6 +118,8 @@ UKUITaskButton::UKUITaskButton(QString appName,const WId window, UKUITaskBar * t
             updateIcon();
         }
     });
+    connect(KWindowSystem::self(), static_cast<void (KWindowSystem::*)(WId, NET::Properties, NET::Properties2)>(&KWindowSystem::windowChanged)
+                , this, &UKUITaskButton::updateIcon);
 }
 
 /************************************************


### PR DESCRIPTION
不开启kwin的时候不显示夜间模式图标
满足安卓兼容窗口图标变化后任务栏图标实时更新的需求
添加/usr/share/pixmaps路径的图标搜索